### PR TITLE
https://github.com/jamlo/ : April 5, 2014

### DIFF
--- a/ivy.xml
+++ b/ivy.xml
@@ -5,7 +5,7 @@
     <conf name="runtime" extends="build" description="Libraries that need to be included with project jar" />
     </configurations>
     <dependencies>
-        <dependency org="commons-lang" name="commons-lang" rev="2.4" conf="build->default"/>
+        <dependency org="org.apache.commons" name="commons-lang3" rev="3.0" conf="build->default"/>
         <dependency org="commons-io" name="commons-io" rev="1.4" conf="build->default"/>
         <dependency org="commons-jexl" name="commons-jexl" rev="1.1" conf="build->default"/>
         <dependency org="commons-codec" name="commons-codec" rev="1.4" conf="build->default"/>

--- a/src/main/com/zeroclue/jmeter/protocol/amqp/AMQPSampler.java
+++ b/src/main/com/zeroclue/jmeter/protocol/amqp/AMQPSampler.java
@@ -15,7 +15,7 @@ import com.rabbitmq.client.Channel;
 import com.rabbitmq.client.Connection;
 import com.rabbitmq.client.ConnectionFactory;
 import com.rabbitmq.client.MessageProperties;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 public abstract class AMQPSampler extends AbstractSampler implements ThreadListener {
 


### PR DESCRIPTION
Bug Fix: migrated the code to use the apache-commons-lang3 library instead of the apache-commons-lang.
Reason: The plugin will crash when you try to run it on the latest version (2.11) of apache-jmeter that has already upgraded to the apache-lang3 library.

The stacktrace was:

ERROR - jmeter.threads.JMeterThread: Test failed! java.lang.NoClassDefFoundError: org/apache/commons/lang/StringUtils
    at com.zeroclue.jmeter.protocol.amqp.AMQPSampler.initChannel(AMQPSampler.java:92)
    at com.zeroclue.jmeter.protocol.amqp.AMQPConsumer.initChannel(AMQPConsumer.java:304)
    at com.zeroclue.jmeter.protocol.amqp.AMQPConsumer.sample(AMQPConsumer.java:56)
    at org.apache.jmeter.threads.JMeterThread.process_sampler(JMeterThread.java:429)
    at org.apache.jmeter.threads.JMeterThread.run(JMeterThread.java:257)
    at java.lang.Thread.run(Thread.java:744)
Caused by: java.lang.ClassNotFoundException: org.apache.commons.lang.StringUtils
    at java.net.URLClassLoader$1.run(URLClassLoader.java:366)
    at java.net.URLClassLoader$1.run(URLClassLoader.java:355)
    at java.security.AccessController.doPrivileged(Native Method)
    at java.net.URLClassLoader.findClass(URLClassLoader.java:354)
    at java.lang.ClassLoader.loadClass(ClassLoader.java:425)
    at java.lang.ClassLoader.loadClass(ClassLoader.java:358)
    ... 6 more
