### PR TITLE
Add an option to share connection and channel between Samplers.

### DIFF
--- a/src/main/com/zeroclue/jmeter/protocol/amqp/AMQPConsumer.java
+++ b/src/main/com/zeroclue/jmeter/protocol/amqp/AMQPConsumer.java
@@ -291,8 +291,15 @@ public class AMQPConsumer extends AMQPSampler implements Interruptible, TestStat
     public void cleanup() {
 
         try {
+        	// TODO: Refactor closing mechanism (cleanup AMQPConsumers before closing connection)
             if (consumerTag != null) {
-               channel.basicCancel(consumerTag);
+            	// If "shareChannel" is enabled, channel may have been already 
+            	// closed by cleanup call from another Sampler
+            	if (channel.isOpen() ) {
+            		channel.basicCancel(consumerTag);
+            	} else {
+            		log.warn("channel.basicCancel not called because channel is already close");
+            	}
             }
         } catch(IOException e) {
             log.error("Couldn't safely cancel the sample " + consumerTag, e);

--- a/src/main/com/zeroclue/jmeter/protocol/amqp/ChannelCache.java
+++ b/src/main/com/zeroclue/jmeter/protocol/amqp/ChannelCache.java
@@ -1,0 +1,62 @@
+package com.zeroclue.jmeter.protocol.amqp;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.jorphan.logging.LoggingManager;
+import org.apache.log.Logger;
+
+import com.rabbitmq.client.Channel;
+
+
+/**
+ * @author rbnxx
+ * ChannelCache caches Channel objects for a given thread (user) with the 
+ * same connection parameters (ie. if several AMQPSamplers are configured
+ * to use the same broker, they will share the same connection and channel). 
+ *
+ */
+class ChannelCache {
+	
+	private static final Logger log = LoggingManager.getLoggerForClass();
+	
+	private final ThreadLocal<Map<String,Channel>> cnxChannelMap = new ThreadLocal<Map<String,Channel>>(){
+		{
+			log.debug("initializing ChannelCache (global)");
+		}
+
+		@Override protected Map<String,Channel> initialValue() {
+			log.debug("initializing ChannelCache HashMap for thread");
+			return new HashMap<String,Channel>();
+		}
+		
+	};
+	
+	public static String genKey(String vhost, String host, String port, String user, String pass, String timeout, Boolean ssl) {
+		// generated as amqp uri (cf. https://www.rabbitmq.com/uri-query-parameters.html )
+		return new StringBuilder()
+				.append(ssl?"amqps://":"amqp://")
+				.append(user)
+				.append(":")
+				.append(pass)
+				.append("@host:")
+				.append(host)
+				.append(":")
+				.append(port)
+				.append("/")
+				.append(vhost)
+				.append("?connection_timeout=")
+				.append(timeout)
+				.toString();
+	}
+	
+	public void set(String cnxString, Channel Channel) {
+		cnxChannelMap.get().put(cnxString, Channel);
+	}
+	
+	public Channel get(String cnxString) {
+		return cnxChannelMap.get().get(cnxString);
+	}
+	
+};
+

--- a/src/main/com/zeroclue/jmeter/protocol/amqp/gui/AMQPSamplerGui.java
+++ b/src/main/com/zeroclue/jmeter/protocol/amqp/gui/AMQPSamplerGui.java
@@ -43,6 +43,7 @@ public abstract class AMQPSamplerGui extends AbstractSamplerGui {
     protected JLabeledTextField username = new JLabeledTextField("Username");
     protected JLabeledTextField password = new JLabeledTextField("Password");
     private final JCheckBox SSL = new JCheckBox("SSL?", false);
+    private final JCheckBox shareChannel = new JCheckBox("Share?", false);
 
     private final JLabeledTextField iterations = new JLabeledTextField("Number of samples to Aggregate");
 
@@ -81,6 +82,7 @@ public abstract class AMQPSamplerGui extends AbstractSamplerGui {
         username.setText(sampler.getUsername());
         password.setText(sampler.getPassword());
         SSL.setSelected(sampler.connectionSSL());
+        shareChannel.setSelected(sampler.shareChannel());
         log.info("AMQPSamplerGui.configure() called");
     }
 
@@ -112,6 +114,7 @@ public abstract class AMQPSamplerGui extends AbstractSamplerGui {
         username.setText("guest");
         password.setText("guest");
         SSL.setSelected(false);
+        shareChannel.setSelected(false);
     }
 
     /**
@@ -145,6 +148,7 @@ public abstract class AMQPSamplerGui extends AbstractSamplerGui {
         sampler.setUsername(username.getText());
         sampler.setPassword(password.getText());
         sampler.setConnectionSSL(SSL.isSelected());
+        sampler.setShareChannel(shareChannel.isSelected());
         log.info("AMQPSamplerGui.modifyTestElement() called, set user/pass to " + username.getText() + "/" + password.getText() + " on sampler " + sampler);
     }
 
@@ -264,6 +268,10 @@ public abstract class AMQPSamplerGui extends AbstractSamplerGui {
         gridBagConstraints.gridy = 2;
         serverSettings.add(SSL, gridBagConstraints);
 
+        gridBagConstraints.gridx = 1;
+        gridBagConstraints.gridy = 3;
+        serverSettings.add(shareChannel, gridBagConstraints);
+        
         gridBagConstraints.gridx = 0;
         gridBagConstraints.gridy = 3;
         serverSettings.add(username, gridBagConstraints);


### PR DESCRIPTION
In a test case with X samplers (AMQPPublisher or AMQPConsumer) connected
to the same broker, if "Share Channel" is enabled, JMeter will open only
1 connection to the broker for each user independently (instead of
opening 1 connection per Sampler and per user).

Note: connection will be closed by the first Sampler cleanup code,
cleanup code for other Samplers sharing the same connection won't be
correctly executed.