### PR TITLE
Update AMQPPublisher.java to fix an if statement

### DIFF
--- a/src/main/com/zeroclue/jmeter/protocol/amqp/AMQPPublisher.java
+++ b/src/main/com/zeroclue/jmeter/protocol/amqp/AMQPPublisher.java
@@ -256,7 +256,7 @@ public class AMQPPublisher extends AMQPSampler implements Interruptible {
             .type(getMessageType())
             .headers(prepareHeaders())
             .build();
-        if (getMessageId() != null && getMessageId().isEmpty()) {
+        if (getMessageId() != null && !getMessageId().isEmpty()) {
             builder.messageId(getMessageId());
         }
         return builder.build();


### PR DESCRIPTION
The if statement is broken and therefore messageId is never sent. This fixes the issue.
