### PR TITLE
[FIX] - fix https required error on dependency downloading

### DIFF
--- a/ivysettings.xml
+++ b/ivysettings.xml
@@ -1,0 +1,27 @@
+<ivysettings>
+    <settings defaultResolver="default"/>
+    <resolvers>
+        <ibiblio name="local-m2" m2compatible="true"
+                 root="file://${user.home}/.m2/repository"
+                 changingPattern=".*SNAPSHOT"/>
+        <ibiblio name="my-maven" m2compatible="true" root="https://repo1.maven.org/maven2/"/>
+        <!--<ibiblio name="staging" m2compatible="true" root="https://oss.sonatype.org/content/repositories/orgagileclick-1008"/>-->
+        <ibiblio name="central" m2compatible="true"/>
+
+        <filesystem name="local-m2-publish" m2compatible="true">
+            <artifact
+                    pattern="${user.home}/.m2/repository/[organisation]/[module]/[revision]/[artifact]-[revision](-[classifier]).[ext]"/>
+        </filesystem>
+
+        <filesystem name="local-m2-publish-snapshot" m2compatible="true">
+            <artifact
+                    pattern="${user.home}/.m2/repository/[organisation]/[module]/[revision]-SNAPSHOT/[artifact]-[revision]-SNAPSHOT.[ext]"/>
+        </filesystem>
+
+        <chain name="default">
+            <resolver ref="central"/>
+            <resolver ref="my-maven"/>
+            <!--<resolver ref="local-m2"/>-->
+        </chain>
+    </resolvers>
+</ivysettings>


### PR DESCRIPTION
I was having a error when building the project to get the .JAR, the error tells me that i needed a HTTPS conection to download the dependencies of the project, so i've made a search on stackoverflow and i was find a solution for the problem, i've been added a ivysettings.xml that adds a "my-maven" resolver to can get the dependencies and built the project.